### PR TITLE
Mrupes/update_tag_format

### DIFF
--- a/include/EXIFTags/TagConstants.h
+++ b/include/EXIFTags/TagConstants.h
@@ -136,7 +136,7 @@ public:
     static const std::vector <double> DEFAULT_DISTORTION;
     static const std::vector <double> DEFAULT_POSE;
     static const std::string DEFAULT_TIMESTAMP_FORMAT;
-    static const std::string SECONDARY_TIMESTAMP_FORMAT;
+    static const std::string PRIMARY_TIMESTAMP_FORMAT;
     static const ExifByteOrder DEFAULT_BYTE_ORDER;
     static const int MIN_IMAGE_SIZE;
 };

--- a/src/TagConstants.cpp
+++ b/src/TagConstants.cpp
@@ -91,6 +91,7 @@ const std::vector <double> Constants::DEFAULT_CAM_MATRIX = {500.0, 500.0, 1024.0
 const std::vector <double> Constants::DEFAULT_DISTORTION = {0.0, 0.0, 0.0, 0.0, 0.0};
 const std::vector <double> Constants::DEFAULT_POSE = {0.0, 0.0, 0.0};
 const std::string Constants::DEFAULT_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S";
+const std::string Constants::PRIMARY_TIMESTAMP_FORMAT = "%Y:%m:%d %H:%M:%S";
 const ExifByteOrder Constants::DEFAULT_BYTE_ORDER = EXIF_BYTE_ORDER_INTEL;
 const int Constants::MIN_IMAGE_SIZE = 10;
 

--- a/src/Tags.cpp
+++ b/src/Tags.cpp
@@ -265,10 +265,12 @@ void Tags::sampleFormat (const std::vector<Tags::SampleFormatType> & type) {
 */
 
 double Tags::exposureTime() const {
-    return dynamic_cast<Tag_UDOUBLE*>(m_tags[Constants::EXPOSURE_TIME].get())->getData();
+    // EXIF exposure tag is in sec, convert sec -> ms
+    return dynamic_cast<Tag_UDOUBLE*>(m_tags[Constants::EXPOSURE_TIME].get())->getData() * 1000.;
 }
 void Tags::exposureTime(double exp) {
-    dynamic_cast<Tag_UDOUBLE*>(m_tags[Constants::EXPOSURE_TIME].get())->setData(exp);
+    // EXIF exposure tag is in sec, convert ms -> sec
+    dynamic_cast<Tag_UDOUBLE*>(m_tags[Constants::EXPOSURE_TIME].get())->setData(exp/1000.);
 }
 
 double Tags::fNumber() const {

--- a/tests/TestConstants.h.i
+++ b/tests/TestConstants.h.i
@@ -33,6 +33,10 @@ public:
         return testDataDir() + "old2gdata.tif";
     };
 
+    static std::string testTifOldVoyis() {
+        return testDataDir() + "legacy_voyis.tif";
+    }
+
     static std::string jpegOutputFile() {
         return testDataDir() + "testout.jpg";
     };

--- a/tests/TestTags.cpp
+++ b/tests/TestTags.cpp
@@ -271,6 +271,20 @@ TEST ( TagsTest, ParseOld2GTifFile) {
     ASSERT_EQ (tags.bitsPerSample()[0], 8);
 }
 
+TEST ( TagsTest, ParseOldVoyisTifFile) {
+    Tags tags; 
+    std::string error_message;
+
+    ASSERT_TRUE (tags.loadHeader(TagsTestCommon::testTifOldVoyis(), error_message));
+
+    ASSERT_EQ (tags.orientation(), Tags::ORIENTATION_EXIF_TOPLEFT);
+    ASSERT_EQ (tags.imageWidth(), 4112);
+    ASSERT_EQ (tags.imageHeight(), 3008);
+    ASSERT_EQ (tags.dateTime(), 1631921861667666);
+    ASSERT_EQ (tags.bitsPerSample().size(), 1);
+    ASSERT_EQ (tags.bitsPerSample()[0], 16);
+}
+
 TEST ( TagsTest, Tags_generate_tag_and_reparse) {
     Tags tags;
     TagsTestCommon::setTags(tags);

--- a/tests/TestTags.cpp
+++ b/tests/TestTags.cpp
@@ -240,7 +240,7 @@ TEST ( TagsTest, ParseJpegFile) {
     ASSERT_EQ (tags.imageHeight(), 480);
     ASSERT_DOUBLE_EQ (tags.fNumber(), 4.7);
     //ASSERT_EQ (tags.make(), "NIKON");
-    ASSERT_DOUBLE_EQ (tags.exposureTime(), 1/95.70000727320055);
+    ASSERT_DOUBLE_EQ (tags.exposureTime(), 1/95.70000727320055 * 1000);
     ASSERT_EQ (tags.latitudeRef(), Tags::LATITUDEREF_NORTH);
     ASSERT_DOUBLE_EQ (tags.latitude(), 43.467081666663894);
 }


### PR DESCRIPTION
- Updates units of exposure tag to sec instead of ms
- Changes dateTime format from YYYY-MM-DDTHH:MM:SS -> YYYY:MM:DD HH:MM:SS